### PR TITLE
fix(auth/frontend): prevent duplicate API calls, expose Keycloak instance for logout and secure API calls

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,11 +15,10 @@ function App() {
     );
   }
 
-  const handleLogout = () => {
-    keycloakAuth.logout({
-      redirectUri: window.location.origin
-    });
-  };
+const handleLogout = () => {
+  if (!keycloakAuth) return;
+  keycloakAuth.logout();
+};
 
   const testBackendConnection = async () => {
     try {
@@ -51,7 +50,7 @@ function App() {
       <Card sx={{ mb: 2 }}>
         <CardContent>
           <Typography variant="h6">User Information</Typography>
-          <Typography><strong>Name:</strong> {user?.name}</Typography>
+          <Typography><strong>Name:</strong> {user?.username}</Typography>
           <Typography><strong>Email:</strong> {user?.email}</Typography>
         </CardContent>
       </Card>

--- a/frontend/src/component/app/AdminPage.jsx
+++ b/frontend/src/component/app/AdminPage.jsx
@@ -52,7 +52,7 @@ const AdminPage = () => {
           {adminData && (
             <Card sx= {{ mt:2 }}>
                 <CardContent>
-                <Typography><strong>User:</strong> {adminData?.adminUser}</Typography>
+                <Typography><strong>User:</strong> {adminData?.username}</Typography>
                  <Typography><strong>Message:</strong> {adminData.message}</Typography>
             </CardContent>
             </Card>

--- a/frontend/src/component/services/api.js
+++ b/frontend/src/component/services/api.js
@@ -10,19 +10,17 @@ const api = axios.create({
 
 // Add request interceptor to attach token
 api.interceptors.request.use(
-    async (config) => {
-        if (keycloakAuth && keycloakAuth.authenticated && keycloakAuth.token) {
+    api.interceptors.request.use(async (config) => {
+        if(keycloakAuth?.authenticated) {
             try {
-                // Refresh token if needed
-                await keycloakAuth.updateToken(30); //refresh if expiring within 30s
+                await keycloakAuth.updateToken(30);
                 config.headers.Authorization = `Bearer ${keycloakAuth.token}`;
-            } catch (err) {
-                console.error("Failed to refresh token:", err);
-                keycloakAuth.logout();
+            } catch {
+                keycloakAuth.logout({ redirectUri: window.location.origin });
             }
         }
         return config;
-    },
+    }),
     (error) => Promise.reject(error)
 );
 


### PR DESCRIPTION
fix(auth/frontend): prevent duplicate API calls, expose Keycloak instance for logout, and secure API calls

_React app using AuthProvider to initialize Keycloak._

_useEffect hooks in ProfilePage and AdminPage fetched data on mount._

**Issues:**

_React StrictMode caused duplicate API calls._
_keycloakAuth instance not exposed in context → logout and token access failed._
_API calls using keycloakAuth.token sometimes failed with undefined._
_Some runtime errors on logout and test connection buttons._

**Step-by-Step Changes**

- Prevent duplicate API calls
- Added effectRan ref in useEffect to skip second run caused by StrictMode.
- Expose Keycloak instance

_AuthProvider now includes keycloakAuth in context._
_This allows components to safely call keycloakAuth.logout() and use token for API calls._

**API fetch adjustments**

_ProfilePage and AdminPage now depend on the user from context._
_Backend API calls wrapped in try/catch with proper error messages._

**Logout and Test Connection**

_Buttons updated to use context-provided keycloakAuth._
_Conditional checks added to prevent undefined errors._

**Why**

- StrictMode in React caused double API requests; prevented to avoid unnecessary load.
- Components need direct access to Keycloak instance for logout and API calls.
- Proper error handling improves UX.
- Ensures role-based access works correctly on frontend pages.
- Frontend Commit Message
